### PR TITLE
fix itemID for SellItem to work

### DIFF
--- a/UI/AuctionHouse/AuctionUI.lua
+++ b/UI/AuctionHouse/AuctionUI.lua
@@ -69,7 +69,16 @@ local function OFGetAuctionSellItemInfo()
     if auctionSellItemInfo == nil then
         return nil
     end
-    return unpack(auctionSellItemInfo)
+
+    local name, texture, count, quality, canUse, price, pricePerUnit, stackCount, totalCount, itemID = unpack(auctionSellItemInfo)
+
+    -- Only fetch itemID from GetItemInfo if it's missing (ignore gold and enchants)
+    if not itemID and name then
+        local itemLink = select(2, GetItemInfo(name))
+        itemID = itemLink and tonumber(string.match(itemLink, "item:(%d+)"))
+    end
+
+    return name, texture, count, quality, canUse, price, pricePerUnit, stackCount, totalCount, itemID
 end
 
 function OFGetCurrentSortParams(type)


### PR DESCRIPTION
now it's possible to post any item via "Create Order" tab

GetAuctionSellItemInfo method is used in this, which is Blizzard API
- there is NO itemID return value (arg10) in 3.3.5, added it via reading the link
- also made sure it doesn't overwrite the "Gold" and "Enchant" custom itemIDs

https://github.com/user-attachments/assets/af11e90a-c718-4bdf-9ed2-1de312e73378

